### PR TITLE
GUI: Show operations spinner with a Gtk.Revealer

### DIFF
--- a/src/Frontend/Widgets/OperationsPopover.vala
+++ b/src/Frontend/Widgets/OperationsPopover.vala
@@ -71,6 +71,7 @@ namespace Taxi {
             row.add (cancel_container);
 
             grid.add (row);
+            grid.show_all ();
         }
 
         public void remove_operation (IOperationInfo operation) {


### PR DESCRIPTION
Gives us a nice animated transition instead of janky adding and removing

This widget is shown when performing file operations. I'm testing with moving a big archive from speedtest.tele2.net 