### PR TITLE
PathBar: misc cleanup

### DIFF
--- a/src/Frontend/Widgets/FilePane.vala
+++ b/src/Frontend/Widgets/FilePane.vala
@@ -224,9 +224,9 @@ namespace Taxi {
 
         private void on_checkbutton_toggle () {
             if (get_marked_row_uris ().size > 0) {
-                path_bar.set_transfer_button_sensitive (true);
+                path_bar.transfer_button_sensitive = true;
             } else {
-                path_bar.set_transfer_button_sensitive (false);
+                path_bar.transfer_button_sensitive = false;
             }
         }
 


### PR DESCRIPTION
* Create a public property for `transfer_button_sensitive` instead of get/set methods. This also allows using a property binding and making the `transfer_button` private.
* Subclass Gtk.Grid instead of Box. Saves setting a few properties
* The variable `location` is never used outside of determining the icon name so just use a local string for this
* `new_xfer_button` is only ever used once so simplify things by removing it
* Use properties instead of set methods for `transfer_button`