### PR TITLE
Filepane sep agnostic

### DIFF
--- a/src/Frontend/MainWindow.vala
+++ b/src/Frontend/MainWindow.vala
@@ -102,7 +102,7 @@ class Taxi.MainWindow : Gtk.ApplicationWindow {
         );
         welcome.vexpand = true;
 
-        local_pane = new FilePane (true);
+        local_pane = new FilePane ();
         local_pane.open.connect (on_local_open);
         local_pane.navigate.connect (on_local_navigate);
         local_pane.file_dragged.connect (on_local_file_dragged);
@@ -118,9 +118,13 @@ class Taxi.MainWindow : Gtk.ApplicationWindow {
         remote_pane.@delete.connect (on_remote_file_delete);
 
         outer_box = new Gtk.Grid ();
-        outer_box.column_homogeneous = true;
         outer_box.add (local_pane);
+        outer_box.add (new Gtk.Separator (Gtk.Orientation.VERTICAL));
         outer_box.add (remote_pane);
+
+        var size_group = new Gtk.SizeGroup (Gtk.SizeGroupMode.HORIZONTAL);
+        size_group.add_widget (local_pane);
+        size_group.add_widget (remote_pane);
 
         alert_stack = new Gtk.Stack ();
         alert_stack.add (welcome);

--- a/src/Frontend/Widgets/FilePane.vala
+++ b/src/Frontend/Widgets/FilePane.vala
@@ -46,24 +46,18 @@ namespace Taxi {
 
         delegate void ActivateFunc (Soup.URI uri);
 
-        public FilePane (bool show_sep = false) {
+        public FilePane () {
             set_orientation (Gtk.Orientation.HORIZONTAL);
-            build (show_sep);
+            build ();
         }
 
-        private void build (bool show_sep) {
+        private void build () {
             inner_grid = new Gtk.Grid ();
             inner_grid.set_orientation (Gtk.Orientation.VERTICAL);
             inner_grid.add (new_path_bar ());
             inner_grid.add (new_list_box ());
             add (inner_grid);
             inner_grid.show_all ();
-
-            if (show_sep) {
-                var sep = new Gtk.Separator (Gtk.Orientation.VERTICAL);
-                sep.get_style_context ().add_class ("pane-separator");
-                add (sep);
-            }
         }
 
         private PathBar new_path_bar () {

--- a/src/Frontend/Widgets/FilePane.vala
+++ b/src/Frontend/Widgets/FilePane.vala
@@ -46,12 +46,7 @@ namespace Taxi {
 
         delegate void ActivateFunc (Soup.URI uri);
 
-        public FilePane () {
-            set_orientation (Gtk.Orientation.HORIZONTAL);
-            build ();
-        }
-
-        private void build () {
+        construct {
             inner_grid = new Gtk.Grid ();
             inner_grid.set_orientation (Gtk.Orientation.VERTICAL);
             inner_grid.add (new_path_bar ());


### PR DESCRIPTION
Removes a little mystery meat and ensures the layout is entirely constructed in main_window

Grid is horizontal by default so we don't need to explicitly set that.