### PR TITLE
Prevent app from trying connexion when url is empty

### DIFF
--- a/src/Frontend/Widgets/ConnectBox.vala
+++ b/src/Frontend/Widgets/ConnectBox.vala
@@ -56,7 +56,9 @@ namespace Taxi {
             var protocol = ((Protocol) protocol_combobox.get_active ()).to_plain_text ();
             var path = path_entry.get_text ();
             var uri = new Soup.URI (protocol + "://" + path);
-            connect_initiated (uri);
+            if (path.length > 0) {
+                connect_initiated (uri);
+            }
         }
 
         private void on_changed () {


### PR DESCRIPTION
Hi!

This is a really easy modification that should solve [#34](https://github.com/Alecaddd/taxi/issues/34). 

Shall we notify the user that he tried a connexion with an empty url ?

Thanks for the review :smiley: 