### PR TITLE
Update to elementary 6 style by putting pathbar in a button

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -1,12 +1,15 @@
+.pathbar {
+  border-left-width: 0;
+  border-right-width: 0;
+  border-radius: 0;
+  border-top-width: 0;
+  padding: 0 6px;
+  }
+
+
 .path-button {
     background: none;
     border-radius: 0;
     border-width: 0;
 }
 
-.button {
-    border-width: 0;
-    border-bottom-width: 1px;
-    border-radius: 0;
-    padding: 0 6px;
-}

--- a/src/Frontend/Widgets/FilePane.vala
+++ b/src/Frontend/Widgets/FilePane.vala
@@ -31,6 +31,7 @@ namespace Taxi {
         private PathBar path_bar;
         private Gtk.ListBox list_box;
         private Gtk.Stack stack;
+        private Gtk.Button path_bar_outer;
 
         public signal void file_dragged (string uri);
         public signal void transfer (string uri);
@@ -76,9 +77,13 @@ namespace Taxi {
             stack.add_named (scrolled_pane, "list");
             stack.add_named (spinner, "spinner");
 
+            path_bar_outer = new Gtk.Button ();
+            path_bar_outer.add (path_bar);
+            path_bar_outer.get_style_context ().add_class ("pathbar");
+
             var inner_grid = new Gtk.Grid ();
             inner_grid.set_orientation (Gtk.Orientation.VERTICAL);
-            inner_grid.add (path_bar);
+            inner_grid.add (path_bar_outer);
             inner_grid.add (stack);
             inner_grid.show_all ();
 


### PR DESCRIPTION
@Alecaddd Hey, this is my first proper pull request for anything. 
This PR updates the pathbar's style to elementary OS 6's by placing it in a Gtk.Button. 
Right now it looks fine imo since I removed most of the padding, but I'm not sure to make the button unclickable (so it doesnt look janky when it's clicked by accident). Would you know how to do this?