### PR TITLE
Application.css: fix combobox styles

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -13,7 +13,7 @@ button.pathbar {
 }
 
 .linked .combo {
-    padding: 2.5px 3px;
+    margin: 1px 0;
 }
 
 .transition {


### PR DESCRIPTION
I'm guessing this was broken during GTK4 port?

## BEFORE
![Screenshot from 2025-06-28 19 01 30](https://github.com/user-attachments/assets/fa6620e7-6a52-4459-ba09-41f73a127775)

## AFTER
![Screenshot from 2025-06-28 18 58 09](https://github.com/user-attachments/assets/14c486c6-0837-4cf0-960f-99087ac84f92)
